### PR TITLE
Fix utf-8 handling on windows.

### DIFF
--- a/functional-programming-lean/book.toml
+++ b/functional-programming-lean/book.toml
@@ -8,19 +8,15 @@ title = "Functional Programming in Lean"
 [build]
 
 [preprocessor.leanexample]
-command = "python scripts/example.py"
-
-[preprocessor.commands]
-command = "python scripts/projects.py"
+command = "python -X utf8 scripts/example.py"
 
 [preprocessor.leanversion]
-command = "python scripts/lean-version.py"
-
+command = "python -X utf8 scripts/lean-version.py"
 
 [output.html]
 additional-css = ["custom.css"]
 
 #[output.pandoc]
-#command = "python ../../scripts/one-markdown.py"
+#command = "python -X utf8 ../../scripts/one-markdown.py"
 
 [output.wordcount]


### PR DESCRIPTION
Use the new Python 3.7 UTF-8 Mode feature, see https://peps.python.org/pep-0540/