### PR TITLE
Typo fix at MonadTransformers.lean

### DIFF
--- a/examples/Examples/MonadTransformers.lean
+++ b/examples/Examples/MonadTransformers.lean
@@ -321,10 +321,10 @@ stop book declaration
 
 book declaration {{{ showFileAndDir }}}
   def showFileName (file : String) : ConfigIO Unit := do
-    IO.println s!"{(← read).currentPrefix} {file}"
-
+    IO.println ((← read).fileName file)
+  
   def showDirName (dir : String) : ConfigIO Unit := do
-    IO.println s!"{(← read).currentPrefix} {dir}/"
+    IO.println ((← read).dirName dir)
 stop book declaration
 
 


### PR DESCRIPTION
Maybe typo. The functions defined in the previous section shall be right, but here, the functions will give unwanted result.

Before.
```
 bin/
│    hello.hash
│    hello.trace
│    hello
```
After, should be.
```
├── bin/
│   ├── hello.hash
│   ├── hello.trace
│   ├── hello
```