### PR TITLE
Fix 2 more instances of leanprover/fp-lean#137

### DIFF
--- a/examples/Examples/Classes.lean
+++ b/examples/Examples/Classes.lean
@@ -781,9 +781,9 @@ stop book declaration
 
 
 book declaration {{{ spiderBoundsChecks }}}
-theorem atLeastThreeSpiders : idahoSpiders.inBounds 2 := by simp
+theorem atLeastThreeSpiders : idahoSpiders.inBounds 2 := by decide
 
-theorem notSixSpiders : ¬idahoSpiders.inBounds 5 := by simp
+theorem notSixSpiders : ¬idahoSpiders.inBounds 5 := by decide
 stop book declaration
 
 namespace Demo


### PR DESCRIPTION
This follows Adam's suggestion to use `decide` instead of `simp`. I've verified that these 2 lines build on Lean 4.3 and 4.4.

Why a pull request: I did read [CONTRIBUTING.md](https://github.com/leanprover/fp-lean/blob/master/CONTRIBUTING.md), though I still chose to open a pull request:
- I'm a Microsoft employee, and I've linked my account with the Microsoft org, so I shouldn't need to sign a separate CLA.
- I'm under the impression that this fix falls into the category of "having prior discussion" (#137), and I saw similar fix was done in 3a53e94.