### PR TITLE
Fix idahoSpiders bounds check examples

### DIFF
--- a/examples/Examples/Classes.lean
+++ b/examples/Examples/Classes.lean
@@ -781,9 +781,9 @@ stop book declaration
 
 
 book declaration {{{ spiderBoundsChecks }}}
-theorem atLeastThreeSpiders : idahoSpiders.inBounds 2 := by simp
+theorem atLeastThreeSpiders : idahoSpiders.inBounds 2 := by simp [idahoSpiders]
 
-theorem notSixSpiders : ¬idahoSpiders.inBounds 5 := by simp
+theorem notSixSpiders : ¬idahoSpiders.inBounds 5 := by simp [idahoSpiders]
 stop book declaration
 
 namespace Demo


### PR DESCRIPTION
The examples do not work in the latest version of Lean (4.16.0), but adding `[idahoSpiders]` solves the issue.