### PR TITLE
fix: don't copy giant files to temp containers

### DIFF
--- a/book/lake-manifest.json
+++ b/book/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "38b11d9518e544b08b5b27e91197dfdb2b86690a",
+   "rev": "c68870b3fd3ae8e99ea242bf17197db3b0d39b0f",
    "name": "verso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
This makes the build process much more friendly for smaller disks.