### PR TITLE
Correct typo in MonadTransformers section

### DIFF
--- a/book/FPLean/MonadTransformers.lean
+++ b/book/FPLean/MonadTransformers.lean
@@ -34,7 +34,7 @@ For example:
 Writing each monad by hand is tedious, however, involving boilerplate definitions of the various type classes.
 Each of these components can also be extracted to a definition that modifies some other monad to add an additional effect.
 Such a definition is called a _monad transformer_.
-A concrete monad can be build from a collection of monad transformers, which enables much more code re-use.
+A concrete monad can be built from a collection of monad transformers, which enables much more code re-use.
 
 {include 1 FPLean.MonadTransformers.ReaderIO}
 


### PR DESCRIPTION
The past participle of 'build' is 'built'.