### PR TITLE
docs(UniversePattern): fix Finite.enumerate .pair prose (dom/cod -> t1/t2)

### DIFF
--- a/book/FPLean/DependentTypes/UniversePattern.lean
+++ b/book/FPLean/DependentTypes/UniversePattern.lean
@@ -193,7 +193,7 @@ The implementation of {anchorName FiniteAll}`enumerate` is also by recursion on 
 In the case for {anchorName Finite}`Unit`, there is only a single value.
 In the case for {anchorName Finite}`Bool`, there are two values to return ({anchorName sundries}`true` and {anchorName sundries}`false`).
 In the case for pairs, the result should be the Cartesian product of the values for the type coded for by {anchorName FiniteAll}`t1` and the values for the type coded for by {anchorName FiniteAll}`t2`.
-In other words, every value from {anchorName FiniteAll}`dom` should be paired with every value from {anchorName FiniteAll}`cod`.
+In other words, every value from {anchorName FiniteAll}`t1` should be paired with every value from {anchorName FiniteAll}`t2`.
 The helper function {anchorName ListProduct}`List.product` can certainly be written with an ordinary recursive function, but here it is defined using {kw}`for` in the identity monad:
 
 ```anchor ListProduct


### PR DESCRIPTION
## Summary

The \`.pair\` branch of \`Finite.enumerate\` pattern-matches on \`.pair t1 t2\` and uses \`t1.enumerate.product t2.enumerate\`. The prose directly below (line 196) read:

> In other words, every value from \`dom\` should be paired with every value from \`cod\`.

\`dom\`/\`cod\` are the names used in the \`.arr\` branch on the next line, not the pair branch. Fixed the prose to reference \`t1\`/\`t2\` to match the code being described.

Closes #269

## Testing

Docs-only change; one line.