### PR TITLE
chore: remove expect requirement and clean up modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Install expect
-      run: sudo apt-get install -y expect
+    - name: Install a C compiler
+      run: sudo apt-get install -y build-essential
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@ This repository contains the source code of the book Functional Programming in L
 
 The original version of the book was released by Microsoft Corporation in 2023 under a Creative Commons Attribution 4.0 International License. The current version has been modified by the author from the original version to account for changes in newer versions of Lean and to use Verso; these changes are copyright 2023-2025 Lean FRO, LLC. A detailed account of the changes can be found in the book's [source code repository](https://github.com/leanprover/fp-lean/).
 
+Generally speaking, the code in this repository is not intended to work on all computers. The purpose of the repository is to produce the book's HTML for readers. In particular, it probably only works on Unix-like systems, due to the way that the built-in tests exercise the programs built in the book. Building the book requires at least a C compiler available as `cc`, with the POSIX headers, and a Unix-like shell.
 
-The book's build has been tested with:
-
-1. Lean 4 (see the version in lean-toolchain in examples/)
-2. expect (tested with v5.45.4 but any version from the last decade should work)
-
-To build the book, change to the "book" directory and run "lake exe fp-lean". After this, "book/out/html-multi" contains a multi-page Web version of the book.
+To build the book, change to the [`book`](book/) directory and run `lake exe fp-lean`. After this, `book/out/html-multi` contains a multi-page Web version of the book.
 

--- a/book/FPLean/Examples.lean
+++ b/book/FPLean/Examples.lean
@@ -3,6 +3,7 @@ import Lean.Data.NameMap
 import Lean.DocString.Syntax
 import VersoManual
 import FPLean.Examples.Commands
+import FPLean.Examples.Interaction
 import FPLean.Examples.OtherLanguages
 
 open Lean (NameMap MessageSeverity)
@@ -662,6 +663,17 @@ def command : RoleExpander
     unless output.stderr.isEmpty do
       logSilentInfo <| "Stderr:\n" ++ output.stderr
     let out := «show».getD cmd |>.getString
+    return #[← ``(Inline.other (Inline.shellCommand $(quote out)) #[Inline.code $(quote out)])]
+
+/--
+A command invocation.
+-/
+@[role_expander commandLine]
+def commandLine : RoleExpander
+  | args, inls => do
+    ArgParse.done.run args
+    let cmd ← oneCodeStr inls
+    let out := cmd.getString
     return #[← ``(Inline.other (Inline.shellCommand $(quote out)) #[Inline.code $(quote out)])]
 
 structure CommandBlockConfig extends CommandConfig where

--- a/book/FPLean/Examples/Commands.lean
+++ b/book/FPLean/Examples/Commands.lean
@@ -1,7 +1,11 @@
-import FPLean.Examples.Commands.Env
-import FPLean.Examples.Commands.ShLex
-import Lean.Elab
-import Verso.FS
+module
+public import FPLean.Examples.Commands.Env
+public import FPLean.Examples.Commands.ShLex
+public import Lean.Environment
+public import Lean.Exception
+public import Verso.FS
+
+public section
 
 namespace FPLean.Commands
 open Lean
@@ -51,6 +55,29 @@ private def fixPath (path : String) :=
     |>.toList
     |> System.SearchPath.separator.toString.intercalate
 
+private def examplesBinDir : IO String := do
+  return ((← IO.currentDir) / ".." / "examples" / ".lake" / "build" / "bin").toString
+
+private def inheritedPath : IO String := do
+  return (← IO.getEnv "PATH").map (System.SearchPath.separator.toString ++ ·) |>.getD ""
+
+/--
+The environment for commands run in a container.
+
+The binaries built from the examples come first on the `PATH`, and the variables that Lake sets
+for the book's own build are removed.
+-/
+def containerEnv : IO (Array (String × Option String)) := do
+  let path := (← examplesBinDir) ++ fixPath (← inheritedPath)
+  return #[("PATH", some path)] ++ lakeVars.map (·, none) ++ localeVars.map (·, some "C.UTF-8")
+
+/-- The environment from `containerEnv`, as `"NAME=VALUE"` entries to add and names to remove. -/
+def containerEnvEntries : IO (Array String × Array String) := do
+  let env ← containerEnv
+  return (
+    env.filterMap fun (name, value?) => value?.map fun value => s!"{name}={value}",
+    env.filterMap fun (name, value?) => if value?.isNone then some name else none)
+
 
 def command (container : Ident) (dir : System.FilePath) (command : StrLit) (viaShell := false) : m IO.Process.Output := do
   let c ← ensureContainer container
@@ -59,14 +86,11 @@ def command (container : Ident) (dir : System.FilePath) (command : StrLit) (viaS
   let dir := c.workingDirectory / "examples" / dir
   IO.FS.createDirAll dir
   let (cmd, args) ← if viaShell then pure ("bash", #["-c", command.getString]) else cmdAndArgs
-  let extraPath := (← IO.currentDir) / ".." / "examples" / ".lake" / "build" / "bin" |>.toString
-  let extraPath := if extraPath.contains ' ' || extraPath.contains '"' || extraPath.contains '\'' then extraPath.quote else extraPath
-  let path := (← IO.getEnv "PATH").map (System.SearchPath.separator.toString ++ ·) |>.getD ""
   let out ← IO.Process.output {
     cmd := cmd,
     args := args,
     cwd := dir,
-    env := #[("PATH", some (extraPath ++ fixPath path))] ++ lakeVars.map (·, none) ++ localeVars.map (·, some "C.UTF-8")
+    env := ← containerEnv
   }
   if out.exitCode != 0 then
     let stdout := m!"Stdout: {indentD out.stdout}"

--- a/book/FPLean/Examples/Commands/Env.lean
+++ b/book/FPLean/Examples/Commands/Env.lean
@@ -1,8 +1,10 @@
-import Lean.Environment
-import Std.Data.HashMap
+module
+public import Lean.Environment
+public import Std.Data.HashMap
 import SubVerso.Highlighting.Highlighted
 import SubVerso.Module
 
+public section
 
 open Lean Std
 

--- a/book/FPLean/Examples/Commands/ShLex.lean
+++ b/book/FPLean/Examples/Commands/ShLex.lean
@@ -1,3 +1,5 @@
+module
+
 namespace FPLean.Commands.Shell
 
 private inductive State where
@@ -6,7 +8,7 @@ private inductive State where
   | inDouble
   | escaped (st : State)
 
-def shlex (cmd : String) : Except String (Array String) := do
+public def shlex (cmd : String) : Except String (Array String) := do
   let mut state : State := .normal
   let mut iter := cmd.startPos
   let mut out : Array String := #[]

--- a/book/FPLean/Examples/Interaction.lean
+++ b/book/FPLean/Examples/Interaction.lean
@@ -1,0 +1,190 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+public meta import Expect.Run
+public meta import FPLean.Examples.Commands
+public import Lean.Exception
+public import Lean.CoreM
+public import Verso.Doc.ArgParse
+public import VersoManual
+
+public section
+
+/-!
+Sessions with interactive programs.
+
+The body of an {lit}`interaction` block is a script in the `Expect` language, which says what the
+program is expected to write and what is typed in response. Elaborating the block runs the script
+against the real program, and the transcript that results is what the book shows.
+-/
+
+open Lean.Doc.Syntax
+open Verso Doc Elab Genre.Manual ArgParse Output Html Log SyntaxUtils
+open Lean Elab Term Meta
+
+namespace FPLean
+
+structure InteractionConfig where
+  container : Ident
+  dir : StrLit
+  /-- Whether the transcript begins with the command that started the session. -/
+  showCommand : Bool
+
+meta instance [Monad m] [MonadError m] [MonadLiftT CoreM m] : FromArgs InteractionConfig m where
+  fromArgs :=
+    InteractionConfig.mk <$> .positional `container .ident <*> .positional `dir .strLit <*>
+      .flag `showCommand true
+
+private meta def roleName : Expect.Role → String
+  | .command => "command"
+  | .output => "output"
+  | .input => "input"
+
+/--
+Whether a line separates a script from the transcript that it is expected to produce.
+-/
+private meta def isSeparator (line : String) : Bool :=
+  let dashes := line.dropWhile ' ' |>.dropEndWhile Char.isWhitespace
+  !(dashes.drop 2).isEmpty && dashes.all '-'
+
+/--
+Puts a block's indentation back on each line of text that it is compared against.
+-/
+private meta def indentBy (indent : String) (text : String) : String :=
+  if indent.isEmpty then text
+  else
+    text.lines.map indentLine |>.toList |> String.join
+where
+  indentLine line :=
+    let line := line.toString
+    if line.isEmpty then "\n" else indent ++ line ++ "\n"
+
+private unsafe def evalSessionUnsafe (stx : Syntax) : TermElabM (Option Expect.Session) := do
+  let type := Lean.mkConst ``Expect.Session
+  let e ← withoutErrToSorry <| Elab.Term.elabTerm stx (some type)
+  Term.synthesizeSyntheticMVarsNoPostponing
+  let e ← instantiateMVars e
+  if e.hasSorry || e.hasExprMVar then return none
+  some <$> evalExpr Expect.Session type e
+
+@[implemented_by evalSessionUnsafe]
+private meta opaque evalSession (stx : Syntax) : TermElabM (Option Expect.Session)
+
+block_extension Block.interaction (segments : Array (String × String)) where
+  traverse _ _ _ := pure none
+  data := toJson segments
+  toTeX := none
+  toHtml := some fun _ _ _ data _ => do
+    let .ok (segments : Array (String × String)) := fromJson? data
+      | reportError s!"Failed to deserialize interaction:\n{data}"
+        return .empty
+    let pieces : Array Html := segments.map fun (content, who) =>
+      {{ <code class={{who}}>{{content}}</code> }}
+    pure {{
+      <div class="interaction">{{pieces}}</div>
+    }}
+  extraCss := [
+    r#"
+.interaction {
+  overflow-x: auto;
+}
+.interaction > * {
+  display: inline;
+  white-space: pre;
+}
+.interaction .command::before {
+  content: "$ ";
+  font-weight: 600;
+}
+.interaction .input {
+  font-weight: 600;
+  color: #0000c0;
+}
+
+div.paragraph > .interaction:not(:first-child) {
+  margin-top: 0.5rem;
+}
+
+div.paragraph > .interaction:not(:last-child) {
+  margin-bottom: 0.5rem;
+}
+"#
+  ]
+
+@[code_block_expander interaction]
+meta def interaction : CodeBlockExpander
+  | args, str => do
+    let {container, dir, showCommand} ← parseThe InteractionConfig args
+    let directory : System.FilePath := dir.getString
+    unless directory.isRelative do
+      throwErrorAt dir "Relative directory expected, got '{dir.getString}'"
+
+    -- Before the script, so that a failure here does not leave later blocks without a container
+    let c ← Commands.ensureContainer container
+    let cwd := c.workingDirectory / "examples" / directory
+    IO.FS.createDirAll cwd
+
+    let (script, expected, indent) ← blockParts str
+    let stx ← parseStrLitAsCategory `term script
+    if stx.isMissing then return #[]
+    let some session ← evalSession stx
+      | throwErrorAt str "Could not evaluate the script"
+
+    let (envOverrides, envUnset) ← Commands.containerEnvEntries
+
+    match ← Expect.run session cwd envOverrides envUnset with
+    | .error (why, transcript) =>
+      throwErrorAt str "{why}\nTranscript:{indentD transcript.toString}"
+    | .ok transcript =>
+      let shown := if showCommand then transcript else transcript.filter (!·.role matches .command)
+      let actual := shown.toString
+      logSilentInfo actual
+      discard <| ExpectString.expectString "transcript" expected (indentBy indent actual)
+        (preEq := (·.trimAsciiEnd.copy))
+      let segments := shown.map fun ⟨content, who⟩ =>
+        (if who matches .command then content ++ "\n" else content, roleName who)
+      return #[← ``(Block.other (Block.interaction $(quote segments)) #[])]
+where
+  /--
+  The script that a block contains, the transcript that it is expected to produce, and the
+  indentation that the block carries in the source.
+
+  The two parts are string literals that point at their own part of the block, so that errors and
+  replacements land where they belong. A block that is nested in a list or an admonition is
+  indented in the source but not in its contents, and the parts keep the indentation, so that a
+  replacement stays nested where the author put it.
+  -/
+  blockParts (str : StrLit) : DocElabM (StrLit × StrLit × String) := do
+    let some blockStart := str.raw.getPos?
+      | throwErrorAt str "Expected a block with a source position"
+    let blockStop := str.raw.getTailPos?.getD blockStart
+    let text ← getFileMap
+    let sourceLines := (blockStart.extract text.source blockStop).splitOn "\n"
+    let contentLines := str.getString.splitOn "\n"
+    unless sourceLines.length == contentLines.length do
+      throwErrorAt str "The source of this block and its contents do not agree line for line"
+    let indent :=
+      (sourceLines.zip contentLines).findSome? fun (source, content) =>
+        if content.isEmpty then none else some (source.take (source.length - content.length)).copy
+    let mut offset := 0
+    let mut parts := none
+    for (source, content) in sourceLines.zip contentLines do
+      if isSeparator content then
+        parts := some (offset, offset + source.utf8ByteSize + 1)
+        break
+      offset := offset + source.utf8ByteSize + 1
+    let some (scriptEnd, transcriptStart) := parts
+      | throwErrorAt str
+          "Expected a line of three or more dashes, separating the script from the transcript that \
+           it is expected to produce"
+    let offsetOf (offset : Nat) : String.Pos.Raw := ⟨blockStart.byteIdx + offset⟩
+    return (part blockStart (offsetOf scriptEnd) text,
+            part (offsetOf transcriptStart) blockStop text,
+            indent.getD "")
+  /-- The part of a block between two positions, as a string literal that points at it. -/
+  part (start stop : String.Pos.Raw) (text : FileMap) : StrLit :=
+    Syntax.mkStrLit (start.extract text.source stop)
+      (info := .original "".toRawSubstring start "".toRawSubstring stop)

--- a/book/FPLean/Examples/OtherLanguages.lean
+++ b/book/FPLean/Examples/OtherLanguages.lean
@@ -1,8 +1,13 @@
+module
 import SubVerso.Examples
 import Lean.Data.NameMap
 import Std.Data.HashMap
 import VersoManual
 import Lean.DocString.Syntax
+public import Verso.Doc.Elab.Monad
+public meta import Verso.ExpectString
+
+public section
 
 open Lean (NameMap MessageSeverity)
 open Lean.Doc.Syntax
@@ -18,12 +23,12 @@ open Lean
 -- TODO syntax highlighting for C#, TypeScript, Python etc (use the same technique as C in the manual)
 
 @[code_block_expander CSharp]
-def CSharp : CodeBlockExpander
+meta def CSharp : CodeBlockExpander
   | _args, code => do
     return #[← ``(Block.code $(quote code.getString))]
 
 @[role_expander CSharp]
-def inlineCSharp : RoleExpander
+meta def inlineCSharp : RoleExpander
   | _args, code => do
     let #[code] := code
       | throwErrorAt (mkNullNode code) "Expected exactly one code argument"
@@ -32,12 +37,12 @@ def inlineCSharp : RoleExpander
     return #[← ``(Inline.code $(quote code.getString))]
 
 @[code_block_expander Kotlin]
-def Kotlin : CodeBlockExpander
+meta def Kotlin : CodeBlockExpander
   | _args, code => do
     return #[← ``(Block.code $(quote code.getString))]
 
 @[role_expander Kotlin]
-def inlineKotlin : RoleExpander
+meta def inlineKotlin : RoleExpander
   | _args, code => do
     let #[code] := code
       | throwErrorAt (mkNullNode code) "Expected exactly one code argument"
@@ -46,12 +51,12 @@ def inlineKotlin : RoleExpander
     return #[← ``(Inline.code $(quote code.getString))]
 
 @[code_block_expander cpp]
-def cpp : CodeBlockExpander
+meta def cpp : CodeBlockExpander
   | _args, code => do
     return #[← ``(Block.code $(quote code.getString))]
 
 @[role_expander cpp]
-def inlineCpp : RoleExpander
+meta def inlineCpp : RoleExpander
   | _args, code => do
     let #[code] := code
       | throwErrorAt (mkNullNode code) "Expected exactly one code argument"
@@ -61,12 +66,12 @@ def inlineCpp : RoleExpander
 
 
 @[code_block_expander typescript]
-def typescript : CodeBlockExpander
+meta def typescript : CodeBlockExpander
   | _args, code => do
     return #[← ``(Block.code $(quote code.getString))]
 
 @[role_expander typescript]
-def inlineTypescript : RoleExpander
+meta def inlineTypescript : RoleExpander
   | _args, code => do
     let #[code] := code
       | throwErrorAt (mkNullNode code) "Expected exactly one code argument"
@@ -75,7 +80,7 @@ def inlineTypescript : RoleExpander
     return #[← ``(Inline.code $(quote code.getString))]
 
 @[role_expander c]
-def c : RoleExpander
+meta def c : RoleExpander
   | _args, code => do
     let #[code] := code
       | throwErrorAt (mkNullNode code) "Expected exactly one code argument"
@@ -84,7 +89,7 @@ def c : RoleExpander
     return #[← ``(Inline.code $(quote code.getString))]
 
 @[role_expander java]
-def java : RoleExpander
+meta def java : RoleExpander
   | _args, code => do
     let #[code] := code
       | throwErrorAt (mkNullNode code) "Expected exactly one code argument"
@@ -93,7 +98,7 @@ def java : RoleExpander
     return #[← ``(Inline.code $(quote code.getString))]
 
 @[role_expander rust]
-def rust : RoleExpander
+meta def rust : RoleExpander
   | _args, code => do
     let #[code] := code
       | throwErrorAt (mkNullNode code) "Expected exactly one code argument"
@@ -102,12 +107,12 @@ def rust : RoleExpander
     return #[← ``(Inline.code $(quote code.getString))]
 
 @[code_block_expander python]
-def python : CodeBlockExpander
+meta def python : CodeBlockExpander
   | _args, code => do
     return #[← ``(Block.code $(quote code.getString))]
 
 @[role_expander python]
-def inlinePython : RoleExpander
+meta def inlinePython : RoleExpander
   | _args, code => do
     let #[code] := code
       | throwErrorAt (mkNullNode code) "Expected exactly one code argument"
@@ -116,12 +121,12 @@ def inlinePython : RoleExpander
     return #[← ``(Inline.code $(quote code.getString))]
 
 @[code_block_expander fsharp]
-def fsharp : CodeBlockExpander
+meta def fsharp : CodeBlockExpander
   | _args, code => do
     return #[← ``(Block.code $(quote code.getString))]
 
 @[role_expander fsharp]
-def fsharpInline : RoleExpander
+meta def fsharpInline : RoleExpander
   | _args, code => do
     let #[code] := code
       | throwErrorAt (mkNullNode code) "Expected exactly one code argument"
@@ -131,7 +136,7 @@ def fsharpInline : RoleExpander
 
 
 @[code_block_expander fsharpError]
-def fsharpError : CodeBlockExpander
+meta def fsharpError : CodeBlockExpander
   | _args, code => do
     return #[← ``(Block.code $(quote code.getString))]
 
@@ -140,12 +145,12 @@ section
 
 variable [Monad m] [MonadError m]
 
-structure IncludePythonConfig where
+meta structure IncludePythonConfig where
   file : String
   anchor? : Option Ident
 
-instance : FromArgs IncludePythonConfig m where
-  fromArgs :=   IncludePythonConfig.mk <$> .positional' `file <*> .named' `anchor true
+meta instance : FromArgs IncludePythonConfig m where
+  fromArgs := IncludePythonConfig.mk <$> .positional' `file <*> .named' `anchor true
 
 end
 
@@ -156,7 +161,7 @@ and `false` for an end.
 An anchor consists of a line that contains `ANCHOR:` or `ANCHOR_END:` followed by the name
 of the anchor.
 -/
-def anchor? (line : String) : Except String (String × Bool) := do
+meta def anchor? (line : String) : Except String (String × Bool) := do
   let mut line := line.trimAscii
   line := line.dropWhile (· ≠ 'A')
   if line.startsWith "ANCHOR:" then
@@ -169,7 +174,7 @@ def anchor? (line : String) : Except String (String × Bool) := do
     if line.isEmpty then throw "Expected name after `ANCHOR_END: `" else return (line.copy, false)
   else throw s!"Expected `ANCHOR:` or `ANCHOR_END:`, got {line}"
 
-private def stringAnchors (s : String) : Except String (String × HashMap String String) := do
+private meta def stringAnchors (s : String) : Except String (String × HashMap String String) := do
   let mut out := ""
   let mut anchors : HashMap String String := {}
   let mut openAnchors : HashMap String String := {}
@@ -193,7 +198,7 @@ private def stringAnchors (s : String) : Except String (String × HashMap String
   return (out, anchors)
 
 @[code_block_expander includePython]
-def includePython : CodeBlockExpander
+meta def includePython : CodeBlockExpander
   | args, code => do
     let {file, anchor?} ← parseThe IncludePythonConfig args
     let s ← IO.FS.readFile file

--- a/book/FPLean/HelloWorld/RunningAProgram.lean
+++ b/book/FPLean/HelloWorld/RunningAProgram.lean
@@ -154,14 +154,21 @@ Just as SQL can be thought of as a special-purpose language for interacting with
 
 This program can be run in the same manner as the prior program:
 
-{command helloName "hello-name" "expect -f ./run" (show := "lean --run HelloName.lean")}
+{commandLine}`lean --run HelloName.lean`
 
 If the user responds with {lit}`David`, a session of interaction with the program reads:
 
-```commandOut helloName "expect -f ./run"
-How would you like to be addressed?
-David
-Hello, David!
+```interaction helloName "hello-name" -showCommand
+{ command := "lean", args := #["--run", "HelloName.lean"],
+  script := #[
+    .expect "How would you like to be addressed?",
+    .send "David",
+    .expect "Hello, David!",
+    .exitCode 0] }
+---
+< How would you like to be addressed?
+> David
+< Hello, David!
 ```
 
 The type signature line is just like the one for {lit}`Hello.lean`:

--- a/book/FPLean/MonadTransformers/Do.lean
+++ b/book/FPLean/MonadTransformers/Do.lean
@@ -172,25 +172,44 @@ def main (argv : List String) : IO UInt32 := do
   return 0
 ```
 Running it with no arguments and typing the name {lit}`David` yields the same result as the previous version:
-```commands «early-return» "early-return"
-$ expect -f ./run # lean --run EarlyReturn.lean
-How would you like to be addressed?
-David
-Hello, David!
+```interaction «early-return» "early-return"
+{ command := "lean", args := #["--run", "EarlyReturn.lean"],
+  script := #[
+    .expect "How would you like to be addressed?",
+    .send "David",
+    .expect "Hello, David!",
+    .exitCode 0] }
+---
+$ lean --run EarlyReturn.lean
+< How would you like to be addressed?
+> David
+< Hello, David!
 ```
 
 Providing the name as a command-line argument instead of an answer causes an error:
-```commands «early-return» "early-return"
-$ expect -f ./too-many-args # lean --run EarlyReturn.lean David
-Expected no arguments, but got 1
+```interaction «early-return» "early-return"
+{ command := "lean", args := #["--run", "EarlyReturn.lean", "David"],
+  script := #[
+    .expect "Expected no arguments, but got 1",
+    .exitCode 1] }
+---
+$ lean --run EarlyReturn.lean David
+< Expected no arguments, but got 1
 ```
 
 And providing no name causes the other error:
-```commands «early-return» "early-return"
-$ expect -f ./no-name # lean --run EarlyReturn.lean
-How would you like to be addressed?
-
-No name provided
+```interaction «early-return» "early-return"
+{ command := "lean", args := #["--run", "EarlyReturn.lean"],
+  script := #[
+    .expect "How would you like to be addressed?",
+    .send "",
+    .expect "No name provided",
+    .exitCode 1] }
+---
+$ lean --run EarlyReturn.lean
+< How would you like to be addressed?
+>
+< No name provided
 ```
 
 The program that uses early return avoids needing to nest the control flow, as is done in this version that does not use early return:

--- a/book/FPLean/ProgramsProofs/InsertionSort.lean
+++ b/book/FPLean/ProgramsProofs/InsertionSort.lean
@@ -635,9 +635,14 @@ def main (args : List String) : IO UInt32 := do
 ```
 
 Running it with no arguments produces the expected usage information:
-```commands «sort-sharing» "sort-demo"
-$ expect -f ./run-usage # sort
-Expected single argument, either "--shared" or "--unique"
+```interaction «sort-sharing» "sort-demo"
+{ command := "sort",
+  script := #[
+    .expect "Expected single argument, either \"--shared\" or \"--unique\"",
+    .exitCode 1] }
+---
+$ sort
+< Expected single argument, either "--shared" or "--unique"
 ```
 
 The file {lit}`test-data` contains the following rocks:

--- a/book/expect/Expect.lean
+++ b/book/expect/Expect.lean
@@ -1,0 +1,12 @@
+module
+import Expect.Basic
+import Expect.Buffer
+import Expect.Pty
+public import Expect.Run
+
+/-!
+Scripted terminal sessions.
+
+A script says which command to run, what the program is expected to write, and what is typed in
+response. Running it produces a transcript that records the session as a terminal would show it.
+-/

--- a/book/expect/Expect/Basic.lean
+++ b/book/expect/Expect/Basic.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+public section
+/-!
+The script language for terminal sessions, and the transcripts that running one produces.
+-/
+
+namespace Expect
+
+/-- Who produced a part of a transcript. -/
+inductive Role where
+  /-- The command that started the session. -/
+  | command
+  /-- Text written by the program. -/
+  | output
+  /-- Text typed by the user. -/
+  | input
+deriving Repr, DecidableEq, Inhabited
+
+/-- A run of text in a transcript, all of it from the same source. -/
+structure Segment where
+  text : String
+  role : Role
+deriving Repr, Inhabited
+
+abbrev Transcript := Array Segment
+
+/--
+A step of a terminal session.
+
+The timeouts are in milliseconds, and each bounds its own step. A program that takes its time to
+respond is waited for by the step that expects the response.
+-/
+inductive Directive where
+  /-- Waits for the program to write the given text. -/
+  | expect (text : String) (timeoutMs : UInt32 := 1500)
+  /-- Types a line, and waits for the terminal to echo it into the transcript. -/
+  | send (text : String) (timeoutMs : UInt32 := 1500)
+  /-- Types the character that ends the program's input, which the transcript shows nothing for. -/
+  | sendEOF (timeoutMs : UInt32 := 1500)
+  /-- Waits for the program to terminate, whatever its exit code. -/
+  | exit (timeoutMs : UInt32 := 1500)
+  /-- Waits for the program to terminate with the given exit code. -/
+  | exitCode (code : UInt32) (timeoutMs : UInt32 := 1500)
+deriving Repr, Inhabited
+
+/-- A terminal session: one program, and the steps that drive it. -/
+structure Session where
+  /-- The program to run, which is looked up on the `PATH` that it is given. -/
+  command : String
+  /-- The arguments to pass to the program. -/
+  args : Array String := #[]
+  /-- The steps to take, in order. -/
+  script : Array Directive
+deriving Repr, Inhabited
+
+/--
+The text of a transcript, with each line marked by where it came from: `$` for the command that
+started the session, `>` for what was typed, and `<` for what the program wrote.
+-/
+def Transcript.toString (segments : Transcript) : String := Id.run do
+  let mut out := ""
+  for ⟨text, role⟩ in segments do
+    out := out ++ pre role text
+  return out
+where
+  /-- A line that has no text carries its mark alone, so that no line ends in a space. -/
+  line (mark : String) (text : String) : String :=
+    if text.isEmpty then mark ++ "\n" else s!"{mark} {text}\n"
+  pre
+    | .command, txt => line "$" txt
+    | .output, txt => txt.lines.map (line "<" ·.toString) |>.toList |> String.join
+    | .input, txt => txt.lines.map (line ">" ·.toString) |>.toList |> String.join

--- a/book/expect/Expect/Buffer.lean
+++ b/book/expect/Expect/Buffer.lean
@@ -1,0 +1,152 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+public section
+
+/-!
+Output received from a program, as it arrives.
+
+A read returns whatever bytes happen to be available, which may stop partway through a character,
+so received bytes are decoded as far as they go and the rest is kept for the next read.
+-/
+
+namespace Expect
+
+/--
+Output that has been received but not yet used.
+
+Bytes at the end that do not yet form a whole character are kept apart until the rest of that
+character arrives.
+-/
+structure Buffer where
+  /-- The text received so far. -/
+  text : String := ""
+  /-- Bytes of a character whose remaining bytes have not arrived. There are at most three. -/
+  incomplete : ByteArray := .empty
+  /-- Whether a carriage return has arrived whose following character has not. -/
+  heldReturn : Bool := false
+deriving Inhabited
+
+/--
+The number of bytes at the end that begin a character whose remaining bytes have not arrived yet.
+
+A character is at most four bytes long, and every byte after the first has `10` as its two high
+bits, so only the last three bytes can belong to an unfinished character.
+-/
+private def incompleteSuffix (bytes : ByteArray) : Nat := Id.run do
+  for back in [1, 2, 3] do
+    if back ≤ bytes.size then
+      let b := bytes.get! (bytes.size - back)
+      unless b &&& 0xc0 == 0x80 do
+        let width :=
+          if b &&& 0x80 == 0x00 then 1
+          else if b &&& 0xe0 == 0xc0 then 2
+          else if b &&& 0xf0 == 0xe0 then 3
+          else if b &&& 0xf8 == 0xf0 then 4
+          else 1
+        return if back < width then back else 0
+  return 0
+
+/--
+Adds received bytes, decoding as many of them as form whole characters.
+
+The result is `none` when the bytes are not text at all. A terminal writes a carriage return before
+each newline, and each such pair becomes a newline here. A carriage return at the very end is held
+back until the character after it arrives, so that a pair split across two reads is recognized.
+-/
+def Buffer.push (buffer : Buffer) (bytes : ByteArray) : Option Buffer := do
+  let received := buffer.incomplete ++ bytes
+  let whole := received.size - incompleteSuffix received
+  let text ← String.fromUTF8? (received.extract 0 whole)
+  let text := (if buffer.heldReturn then "\r" else "") ++ text
+  let text := text.replace "\r\n" "\n"
+  let heldReturn := text.endsWith "\r"
+  return {
+    text := buffer.text ++ (if heldReturn then text.dropEnd 1 else text)
+    incomplete := received.extract whole received.size
+    heldReturn
+  }
+
+/-- Whether no text is waiting to be used. -/
+def Buffer.isEmpty (buffer : Buffer) : Bool :=
+  buffer.text.isEmpty && !buffer.heldReturn
+
+/-- All of the text received, leaving only any unfinished character behind. -/
+def Buffer.flush (buffer : Buffer) : String × Buffer :=
+  (buffer.text ++ (if buffer.heldReturn then "\r" else ""),
+   { buffer with text := "", heldReturn := false })
+
+/--
+The text up to the first occurrence of `pattern`, and what is left once that text and the
+occurrence itself have been used, or `none` if the pattern has not been received.
+-/
+def Buffer.take (buffer : Buffer) (pattern : String) : Option (String × Buffer) := do
+  let text := buffer.text
+  let found ← text.find? pattern
+  let before := (text.sliceTo found)
+  let rest := (text.sliceFrom found).dropPrefix pattern
+  return (before.copy, { buffer with text := rest.copy })
+
+section Tests
+
+private def bytes (s : String) : ByteArray := s.toUTF8
+
+-- Text arrives as text
+#guard ((Buffer.push {} (bytes "Hello")).map (·.text)) == some "Hello"
+
+-- A character split across reads is held back until the rest of it arrives
+#guard
+  let split := "é".toUTF8
+  let first := (Buffer.push {} (split.extract 0 1)).get!
+  let second := (first.push (split.extract 1 2)).get!
+  first.text.isEmpty && first.incomplete.size == 1 &&
+    second.text == "é" && second.incomplete.isEmpty
+
+-- A four-byte character split across three reads
+#guard
+  let split := "🐛".toUTF8
+  let steps := [split.extract 0 1, split.extract 1 3, split.extract 3 4]
+  let whole := steps.foldl (fun b part => (b.push part).get!) ({} : Buffer)
+  whole.text == "🐛" && whole.incomplete.isEmpty
+
+-- The carriage return that a terminal writes before each newline is dropped
+#guard ((Buffer.push {} (bytes "one\r\ntwo\r\n")).map (·.text)) == some "one\ntwo\n"
+
+-- A carriage return and the newline after it are recognized across two reads
+#guard
+  let first := (Buffer.push {} (bytes "one\r")).get!
+  ((first.push (bytes "\ntwo"))).map (·.text) == some "one\ntwo"
+
+-- A carriage return that a program writes on its own is kept
+#guard ((Buffer.push {} (bytes "50%\r99%\r")).map (·.flush.1)) == some "50%\r99%\r"
+
+-- A newline that a program writes itself reaches the terminal as two carriage returns, and the
+-- one that the program wrote survives however the reads are divided
+#guard ((Buffer.push {} (bytes "one\r\r\ntwo")).map (·.text)) == some "one\r\ntwo"
+#guard
+  let first := (Buffer.push {} (bytes "one\r\r\n")).get!
+  ((first.push (bytes "two"))).map (·.text) == some "one\r\ntwo"
+
+-- Bytes that are not text at all are reported
+#guard (Buffer.push {} ⟨#[0xff, 0xfe, 0x41]⟩).isNone
+
+-- Taking a pattern yields what came before it, and uses up the pattern itself
+#guard
+  let buffer := (Buffer.push {} (bytes "Name? David\nHello")).get!
+  match buffer.take "? " with
+  | some (before, rest) => before == "Name" && rest.text == "David\nHello"
+  | none => false
+
+-- A pattern that has not been received yet is not taken
+#guard ((Buffer.push {} (bytes "Nam")).get!.take "Name").isNone
+
+-- Flushing yields everything received, and keeps any unfinished character
+#guard
+  let buffer := (Buffer.push {} (bytes "done\n" ++ "é".toUTF8.extract 0 1)).get!
+  let (text, rest) := buffer.flush
+  text == "done\n" && rest.isEmpty && rest.incomplete.size == 1
+
+end Tests

--- a/book/expect/Expect/Pty.lean
+++ b/book/expect/Expect/Pty.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+public section
+
+/-!
+Child processes running on a pseudoterminal.
+
+A terminal makes programs behave as they do for a person at a keyboard: output is line buffered,
+input is echoed back as it is sent, and standard output and standard error arrive interleaved in
+the order they were written.
+-/
+
+namespace Expect.Pty
+
+private opaque ChildPointed : NonemptyType
+
+/--
+A child process, together with the controlling end of its terminal.
+
+Releasing the last reference to a child closes its terminal, and terminates the process if it is
+still running.
+-/
+def Child : Type := ChildPointed.type
+
+instance : Nonempty Child := ChildPointed.property
+
+/--
+Starts a command on a new pseudoterminal, in the given working directory.
+
+The child's environment is the current one, with the names in `envUnset` removed and the
+`"NAME=VALUE"` entries of `envOverrides` added. The command is looked up on the `PATH` that
+results.
+-/
+@[extern "expect_pty_spawn"]
+private opaque spawnRaw (argv : @& Array String) (envOverrides : @& Array String)
+    (envUnset : @& Array String) (cwd : @& String) : IO Child
+
+/-- Whether the child has produced output, waiting up to `timeoutMs` for some to arrive. -/
+@[extern "expect_pty_poll"]
+opaque Child.ready (child : @& Child) (timeoutMs : UInt32) : IO Bool
+
+/-- Reads what the child has produced. The result is empty once the terminal has closed. -/
+@[extern "expect_pty_read"]
+opaque Child.readBytes (child : @& Child) (max : UInt32) : IO ByteArray
+
+@[extern "expect_pty_write"]
+private opaque writeRaw (child : @& Child) (bytes : @& ByteArray) (timeoutMs : UInt32) : IO Unit
+
+/--
+Sends the character that ends the child's input, taking up to `timeoutMs`.
+
+The terminal shows nothing for it, so a transcript holds only what the program wrote and what was
+typed for it to read.
+-/
+@[extern "expect_pty_write_eof"]
+opaque Child.writeEOF (child : @& Child) (timeoutMs : UInt32) : IO Unit
+
+/-- The child's exit code, or `none` if it is still running after `timeoutMs`. -/
+@[extern "expect_pty_wait"]
+opaque Child.wait (child : @& Child) (timeoutMs : UInt32) : IO (Option UInt32)
+
+/-- Terminates the child and reaps it. -/
+@[extern "expect_pty_kill"]
+opaque Child.kill (child : @& Child) : IO Unit
+
+/-- Releases the terminal. -/
+@[extern "expect_pty_close"]
+opaque Child.close (child : @& Child) : IO Unit
+
+/-- Starts a command on a new pseudoterminal, in the given working directory. -/
+def Child.spawn (cmd : String) (args : Array String) (cwd : System.FilePath)
+    (envOverrides : Array String := #[]) (envUnset : Array String := #[]) : IO Child :=
+  spawnRaw (#[cmd] ++ args) envOverrides envUnset cwd.toString
+
+/-- Reads what the child has produced. The result is empty once the terminal has closed. -/
+def Child.read (child : Child) (max : UInt32 := 4096) : IO ByteArray :=
+  child.readBytes max
+
+/-- Sends text to the child as if it had been typed, taking up to `timeoutMs` altogether. -/
+def Child.write (child : Child) (text : String) (timeoutMs : UInt32 := 1500) : IO Unit :=
+  writeRaw child text.toUTF8 timeoutMs

--- a/book/expect/Expect/Run.lean
+++ b/book/expect/Expect/Run.lean
@@ -1,0 +1,213 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+
+public import Expect.Basic
+import Expect.Buffer
+import Expect.Pty
+
+public section
+
+/-!
+Running a script, which drives one program at a time and records what happened.
+
+Every step that touches the program takes all of the output it has produced, so what is held
+between steps is only what has not been accounted for in the transcript yet.
+-/
+
+namespace Expect
+
+private structure State where
+  /-- Output received from the terminal that is not yet part of the transcript. -/
+  received : Buffer := {}
+  /-- Whether the terminal has closed. -/
+  ended : Bool := false
+  /-- Whether the program has been waited for. -/
+  finished : Bool := false
+  segments : Transcript := #[]
+deriving Inhabited
+
+private def push (segments : Transcript) (text : String) (role : Role) : Transcript :=
+  if text.isEmpty then segments
+  else if let some last := segments.back? then
+    if last.role = role then
+      segments.set! (segments.size - 1) { last with text := last.text ++ text }
+    else segments.push ⟨text, role⟩
+  else segments.push ⟨text, role⟩
+
+private def record (state : IO.Ref State) (text : String) (role : Role) : IO Unit :=
+  state.modify fun s => { s with segments := push s.segments text role }
+
+/-- Checks that the program has not already been waited for. -/
+private def running (state : IO.Ref State) : IO Unit := do
+  if (← state.get).finished then
+    throw <| .userError "The program has already terminated"
+
+/--
+Why waiting for text stopped, as the start of a sentence that names the text.
+
+A program that has gone leaves nothing to wait for, so the reason names what became of it.
+-/
+private def stopped (state : IO.Ref State) (child : Pty.Child) : IO String := do
+  unless (← state.get).ended do return "Timed out waiting for"
+  match ← child.wait 50 with
+  | some code => return s!"The program exited with code {code} before writing"
+  | none => return "The program closed its terminal before writing"
+
+/-- Output received but not yet accounted for in the transcript. -/
+private def unused (state : IO.Ref State) : IO String := do
+  return (← state.get).received.text
+
+/-- Records everything received so far as output of the program. -/
+private def useAll (state : IO.Ref State) : IO Unit := do
+  let (text, rest) := (← state.get).received.flush
+  record state text .output
+  state.modify ({ · with received := rest })
+
+/--
+Takes everything the program has written, waiting until `deadline` for the first of it, and reports
+whether anything arrived.
+
+A program that writes without pause is read until the deadline.
+-/
+private def receive (state : IO.Ref State) (child : Pty.Child) (deadline : Nat) : IO Bool := do
+  if (← state.get).ended then return false
+  let now ← IO.monoMsNow
+  if !(← child.ready (UInt32.ofNat (deadline - now))) then return false
+  let mut got := false
+  repeat
+    let bytes ← child.read
+    if bytes.isEmpty then
+      state.modify ({ · with ended := true })
+      break
+    let some received := (← state.get).received.push bytes
+      | throw <| .userError "The program wrote bytes that are not text"
+    state.modify ({ · with received })
+    got := true
+    if (← IO.monoMsNow) ≥ deadline then break
+    unless ← child.ready 0 do break
+  return got
+
+/--
+Waits for the program to write `pattern`, and returns what it wrote before it, or `none` if the
+program did not write it in time.
+
+The occurrence of the pattern is consumed along with the text before it.
+-/
+private def await (state : IO.Ref State) (child : Pty.Child) (pattern : String)
+    (timeoutMs : UInt32) : IO (Option String) := do
+  let deadline := (← IO.monoMsNow) + timeoutMs.toNat
+  repeat
+    if let some (before, rest) := (← state.get).received.take pattern then
+      state.modify ({ · with received := rest })
+      return some before
+    if (← state.get).ended then break
+    if (← IO.monoMsNow) ≥ deadline then break
+    discard <| receive state child deadline
+  return none
+
+/--
+How long to read for before asking again whether the program has terminated.
+-/
+private def checkEveryMs : Nat := 20
+
+/--
+Reads until the program has terminated and its terminal holds nothing more, or until `deadline`,
+and reports the exit code if it terminated.
+
+Reading continues while the program is on its way out, so that a program with output still to write
+can finish writing it and reach its own exit.
+-/
+private def settle (state : IO.Ref State) (child : Pty.Child) (deadline : Nat) :
+    IO (Option UInt32) := do
+  let mut code ← child.wait 0
+  repeat
+    let now ← IO.monoMsNow
+    if now ≥ deadline then break
+    discard <| receive state child (min deadline (now + checkEveryMs))
+    if code.isNone then code ← child.wait 0
+    if (← state.get).ended then break
+    if code.isSome && !(← child.ready 0) then break
+  -- The terminal can close before the program has been reaped
+  if code.isNone then
+    let now ← IO.monoMsNow
+    if now < deadline then
+      code ← child.wait (UInt32.ofNat (deadline - now))
+  return code
+
+private def step (state : IO.Ref State) (child : Pty.Child) : Directive → IO Unit
+  | .expect text timeoutMs => do
+    running state
+    let some before ← await state child text timeoutMs
+      | throw <| .userError
+          s!"{← stopped state child} {repr text}.\nReceived: {repr (← unused state)}"
+    record state (before ++ text) .output
+  | .send text timeoutMs => do
+    running state
+    -- Whatever the program has written by now came before what is typed
+    useAll state
+    child.write (text ++ "\n") timeoutMs
+    let some before ← await state child (text ++ "\n") timeoutMs
+      | throw <| .userError
+          s!"{← stopped state child} the terminal's echo of {repr text}.\n\
+             Received: {repr (← unused state)}"
+    record state before .output
+    record state (text ++ "\n") .input
+  | .sendEOF timeoutMs => do
+    running state
+    -- Whatever the program has written by now came before the end of input
+    useAll state
+    child.writeEOF timeoutMs
+  | .exit timeoutMs => do
+    discard <| finish state timeoutMs
+  | .exitCode code timeoutMs => do
+    let actual ← finish state timeoutMs
+    if actual != code then
+      throw <| .userError s!"Expected exit code {code}, but got {actual}"
+where
+  /-- Waits for the program to terminate, and reports its exit code. -/
+  finish (state : IO.Ref State) (timeoutMs : UInt32) : IO UInt32 := do
+    running state
+    let code? ← settle state child ((← IO.monoMsNow) + timeoutMs.toNat)
+    useAll state
+    state.modify ({ · with finished := true })
+    let some code := code?
+      | child.kill
+        child.close
+        throw <| .userError s!"The program did not terminate within {timeoutMs} ms"
+    child.close
+    unless (← state.get).received.incomplete.isEmpty do
+      throw <| .userError "The program's output ends partway through a character"
+    return code
+
+/--
+Runs a session in `cwd` and returns its transcript, or the reason it failed together with the
+transcript up to that point.
+
+The program's environment is the current one, with the names in `envUnset` removed and the
+`"NAME=VALUE"` entries of `envOverrides` added.
+-/
+def run (session : Session) (cwd : System.FilePath)
+    (envOverrides : Array String := #[]) (envUnset : Array String := #[]) :
+    IO (Except (String × Transcript) (Transcript)) := do
+  let state : IO.Ref State ← IO.mkRef {}
+  let child ←
+    try Pty.Child.spawn session.command session.args cwd envOverrides envUnset
+    catch e => return .error (toString e, #[])
+  record state (" ".intercalate (session.command :: session.args.toList)) .command
+  try
+    for directive in session.script do
+      step state child directive
+    unless (← state.get).finished do
+      child.kill
+      child.close
+      throw <| .userError "The script ends without waiting for the program to exit"
+    return .ok (← state.get).segments
+  catch e =>
+    unless (← state.get).finished do
+      child.kill
+      child.close
+    return .error (toString e, (← state.get).segments)

--- a/book/expect/native/pty.c
+++ b/book/expect/native/pty.c
@@ -1,0 +1,591 @@
+/*
+POSIX code for spawning and driving a child process on a pseudoterminal.
+
+This is needed to cause Lean to not buffer its output.
+*/
+
+#define _XOPEN_SOURCE 700
+#define _DARWIN_C_SOURCE
+#define _DEFAULT_SOURCE
+
+#include <lean/lean.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <time.h>
+#include <unistd.h>
+
+extern char **environ;
+
+/*
+A running or finished child, reachable from Lean only as an opaque value, so that the process and
+its terminal cannot be named by anything other than the calls below.
+*/
+typedef struct {
+    pid_t pid;
+    int fd;         /* -1 once the terminal has been released */
+    bool reaped;
+    uint32_t code;  /* meaningful once reaped */
+} expect_pty_child;
+
+static void expect_pty_reap(expect_pty_child *child) {
+    int status = 0;
+    while (waitpid(child->pid, &status, 0) < 0 && errno == EINTR) {}
+    child->reaped = true;
+    if (WIFEXITED(status)) child->code = (uint32_t)WEXITSTATUS(status);
+    else if (WIFSIGNALED(status)) child->code = 128 + (uint32_t)WTERMSIG(status);
+}
+
+static void expect_pty_child_finalize(void *ptr) {
+    expect_pty_child *child = (expect_pty_child *)ptr;
+    if (child->fd >= 0) close(child->fd);
+    if (!child->reaped) {
+        kill(child->pid, SIGKILL);
+        expect_pty_reap(child);
+    }
+    free(child);
+}
+
+static void expect_pty_child_foreach(void *ptr, b_lean_obj_arg f) {
+    (void)ptr;
+    (void)f;
+}
+
+static lean_external_class *g_expect_pty_child_class = NULL;
+static pthread_once_t g_expect_pty_child_class_once = PTHREAD_ONCE_INIT;
+
+static void expect_pty_register_child_class(void) {
+    g_expect_pty_child_class =
+        lean_register_external_class(expect_pty_child_finalize, expect_pty_child_foreach);
+}
+
+static lean_external_class *expect_pty_child_class(void) {
+    pthread_once(&g_expect_pty_child_class_once, expect_pty_register_child_class);
+    return g_expect_pty_child_class;
+}
+
+static expect_pty_child *expect_pty_unwrap(b_lean_obj_arg child) {
+    return (expect_pty_child *)lean_get_external_data(child);
+}
+
+static lean_obj_res expect_pty_errno(const char *what, int err) {
+    char buf[512];
+    snprintf(buf, sizeof(buf), "%s: %s", what, strerror(err));
+    return lean_io_result_mk_error(lean_mk_io_user_error(lean_mk_string(buf)));
+}
+
+static lean_obj_res expect_pty_error(const char *what) {
+    return lean_io_result_mk_error(lean_mk_io_user_error(lean_mk_string(what)));
+}
+
+/* Copies a Lean `Array String` into a NULL-terminated array of C strings. */
+static char **expect_pty_strings(b_lean_obj_arg arr, size_t *count) {
+    size_t n = lean_array_size(arr);
+    char **out = (char **)calloc(n + 1, sizeof(char *));
+    if (out == NULL) return NULL;
+    for (size_t i = 0; i < n; i++) {
+        const char *s = lean_string_cstr(lean_array_get_core(arr, i));
+        out[i] = strdup(s);
+        if (out[i] == NULL) {
+            for (size_t j = 0; j < i; j++) free(out[j]);
+            free(out);
+            return NULL;
+        }
+    }
+    if (count != NULL) *count = n;
+    return out;
+}
+
+static void expect_pty_free_strings(char **strs) {
+    if (strs == NULL) return;
+    for (size_t i = 0; strs[i] != NULL; i++) free(strs[i]);
+    free(strs);
+}
+
+/* The length of the name in a "NAME=VALUE" environment entry. */
+static size_t expect_pty_name_len(const char *entry) {
+    const char *eq = strchr(entry, '=');
+    return eq == NULL ? strlen(entry) : (size_t)(eq - entry);
+}
+
+/* Whether a "NAME=VALUE" entry has the given name. */
+static bool expect_pty_named(const char *entry, const char *name, size_t name_len) {
+    return strncmp(entry, name, name_len) == 0 && entry[name_len] == '=';
+}
+
+/*
+The environment for the child: the current one, less the names in `unset`, with the "NAME=VALUE"
+entries of `overrides` replacing or extending what remains.
+
+Built before forking, because the child may only use async-signal-safe calls.
+*/
+static char **expect_pty_child_env(b_lean_obj_arg overrides, b_lean_obj_arg unset) {
+    size_t inherited = 0;
+    while (environ[inherited] != NULL) inherited++;
+    size_t override_count = lean_array_size(overrides);
+    size_t unset_count = lean_array_size(unset);
+
+    char **env = (char **)calloc(inherited + override_count + 1, sizeof(char *));
+    if (env == NULL) return NULL;
+
+    size_t n = 0;
+    for (size_t i = 0; i < inherited; i++) {
+        const char *entry = environ[i];
+        size_t name_len = expect_pty_name_len(entry);
+        bool drop = false;
+        for (size_t j = 0; j < unset_count && !drop; j++) {
+            const char *name = lean_string_cstr(lean_array_get_core(unset, j));
+            drop = strlen(name) == name_len && strncmp(entry, name, name_len) == 0;
+        }
+        for (size_t j = 0; j < override_count && !drop; j++) {
+            const char *o = lean_string_cstr(lean_array_get_core(overrides, j));
+            drop = expect_pty_named(o, entry, name_len);
+        }
+        if (drop) continue;
+        env[n] = strdup(entry);
+        if (env[n] == NULL) goto fail;
+        n++;
+    }
+    for (size_t j = 0; j < override_count; j++) {
+        env[n] = strdup(lean_string_cstr(lean_array_get_core(overrides, j)));
+        if (env[n] == NULL) goto fail;
+        n++;
+    }
+    env[n] = NULL;
+    return env;
+
+fail:
+    expect_pty_free_strings(env);
+    return NULL;
+}
+
+/*
+Allocates a pseudoterminal, returning the controlling end and, in `child_end`, the end that the
+child runs on. On failure the result is -1, and the call that failed and its `errno` are reported in
+`failed` and `err`.
+
+A terminal whose far end nobody holds reports end of input, so the parent takes both ends at once
+and keeps the far one until the child has inherited it. Every moment between the fork and that
+point has a holder, so a read early in the session sees the session as running.
+
+`ptsname` returns a pointer to storage that belongs to the process rather than to the caller, and
+the next call to it overwrites that storage. Lean elaborates in more than one thread, so the whole
+allocation is done under a lock.
+
+Neither descriptor is inherited across an exec, so a process spawned elsewhere in the elaborator
+cannot hold a terminal open behind our back.
+*/
+static int expect_pty_open(int *child_end, const char **failed, int *err) {
+    static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_lock(&lock);
+
+    int controller = posix_openpt(O_RDWR | O_NOCTTY);
+    if (controller < 0) {
+        *failed = "posix_openpt";
+        *err = errno;
+        pthread_mutex_unlock(&lock);
+        return -1;
+    }
+    fcntl(controller, F_SETFD, FD_CLOEXEC);
+    if (grantpt(controller) < 0) {
+        *failed = "grantpt";
+        *err = errno;
+        goto fail;
+    }
+    if (unlockpt(controller) < 0) {
+        *failed = "unlockpt";
+        *err = errno;
+        goto fail;
+    }
+    const char *name = ptsname(controller);
+    if (name == NULL) {
+        *failed = "ptsname";
+        *err = errno;
+        goto fail;
+    }
+    *child_end = open(name, O_RDWR | O_NOCTTY);
+    if (*child_end < 0) {
+        *failed = "open";
+        *err = errno;
+        goto fail;
+    }
+    fcntl(*child_end, F_SETFD, FD_CLOEXEC);
+
+    pthread_mutex_unlock(&lock);
+    return controller;
+
+fail:
+    close(controller);
+    pthread_mutex_unlock(&lock);
+    return -1;
+}
+
+/*
+Finds `command` on the `PATH` that the child will be given, returning a path to run, or NULL if
+there is nothing to run.
+
+The search happens in the parent, where allocation is safe: a forked child may use only
+async-signal-safe calls until it execs, and `execvp` allocates while searching, so a child that
+forked while another thread held the allocator's lock would wait for a thread that does not exist
+in it. Searching here also lets a program that is missing be reported by name.
+
+The entries that name a directory outright are the ones searched, so that the file tested here is
+the file that runs once the child has changed to the directory it was given. A file that can be
+executed is what counts as a match, so that a directory whose name happens to be the command's
+leaves the rest of the `PATH` to be searched.
+*/
+static char *expect_pty_resolve(const char *command, char *const *env) {
+    if (strchr(command, '/') != NULL) return strdup(command);
+
+    const char *path = NULL;
+    for (size_t i = 0; env[i] != NULL; i++) {
+        if (strncmp(env[i], "PATH=", 5) == 0) path = env[i] + 5;
+    }
+    if (path == NULL) path = "/usr/bin:/bin";
+
+    size_t command_len = strlen(command);
+    const char *entry = path;
+    while (true) {
+        const char *sep = strchr(entry, ':');
+        size_t len = sep == NULL ? strlen(entry) : (size_t)(sep - entry);
+
+        if (len > 0 && entry[0] == '/') {
+            char *candidate = (char *)malloc(len + command_len + 2);
+            if (candidate == NULL) return NULL;
+            memcpy(candidate, entry, len);
+            candidate[len] = '/';
+            memcpy(candidate + len + 1, command, command_len);
+            candidate[len + command_len + 1] = '\0';
+            struct stat info;
+            if (stat(candidate, &info) == 0 && S_ISREG(info.st_mode) &&
+                access(candidate, X_OK) == 0) {
+                return candidate;
+            }
+            free(candidate);
+        }
+
+        if (sep == NULL) return NULL;
+        entry = sep + 1;
+    }
+}
+
+/* Starts `argv` on a new pseudoterminal in `cwd`. */
+LEAN_EXPORT lean_obj_res expect_pty_spawn(b_lean_obj_arg argv, b_lean_obj_arg env_overrides,
+                                          b_lean_obj_arg env_unset, b_lean_obj_arg cwd,
+                                          lean_object *world) {
+    (void)world;
+
+    if (lean_array_size(argv) == 0) return expect_pty_error("No command to spawn");
+
+    int child_end = -1;
+    const char *failed = NULL;
+    int err = 0;
+    int controller = expect_pty_open(&child_end, &failed, &err);
+    if (controller < 0) return expect_pty_errno(failed, err);
+
+    /* A fixed size keeps the output of programs that wrap their output reproducible. */
+    struct winsize size;
+    memset(&size, 0, sizeof(size));
+    size.ws_row = 24;
+    size.ws_col = 80;
+    ioctl(controller, TIOCSWINSZ, &size);
+
+    char **args = expect_pty_strings(argv, NULL);
+    char **child_env = expect_pty_child_env(env_overrides, env_unset);
+    char *dir = strdup(lean_string_cstr(cwd));
+    char *program = args == NULL || child_env == NULL ? NULL : expect_pty_resolve(args[0], child_env);
+    if (args == NULL || child_env == NULL || dir == NULL || program == NULL) {
+        bool missing = args != NULL && child_env != NULL && dir != NULL;
+        char message[512];
+        if (missing) snprintf(message, sizeof(message), "Not found on the PATH: %s", args[0]);
+        expect_pty_free_strings(args);
+        expect_pty_free_strings(child_env);
+        free(dir);
+        free(program);
+        close(controller);
+        close(child_end);
+        return expect_pty_error(missing ? message : "Out of memory");
+    }
+    size_t program_len = strlen(program);
+
+    /* Everything that can fail is done before the fork, so that a failure has no child to tidy */
+    expect_pty_child *child = (expect_pty_child *)malloc(sizeof(expect_pty_child));
+    if (child == NULL) {
+        expect_pty_free_strings(args);
+        expect_pty_free_strings(child_env);
+        free(dir);
+        free(program);
+        close(controller);
+        close(child_end);
+        return expect_pty_error("Out of memory");
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        int fork_err = errno;
+        expect_pty_free_strings(args);
+        expect_pty_free_strings(child_env);
+        free(dir);
+        free(program);
+        free(child);
+        close(controller);
+        close(child_end);
+        return expect_pty_errno("fork", fork_err);
+    }
+
+    if (pid == 0) {
+        if (setsid() < 0) _exit(127);
+#ifdef TIOCSCTTY
+        if (ioctl(child_end, TIOCSCTTY, 0) < 0) _exit(127);
+#endif
+        if (dup2(child_end, STDIN_FILENO) < 0) _exit(127);
+        if (dup2(child_end, STDOUT_FILENO) < 0) _exit(127);
+        if (dup2(child_end, STDERR_FILENO) < 0) _exit(127);
+        /*
+        The terminal was opened to close on an exec, and a descriptor that already was one of the
+        three keeps that from the open rather than from a copy, so the exec is allowed for each.
+        */
+        for (int fd = STDIN_FILENO; fd <= STDERR_FILENO; fd++) {
+            int fd_flags = fcntl(fd, F_GETFD, 0);
+            if (fd_flags >= 0) fcntl(fd, F_SETFD, fd_flags & ~FD_CLOEXEC);
+        }
+        if (child_end > STDERR_FILENO) close(child_end);
+        /* A controlling end numbered among the three is a copy of the terminal by now */
+        if (controller > STDERR_FILENO) close(controller);
+        environ = child_env;
+        if (chdir(dir) < 0) _exit(127);
+        execv(program, args);
+        /* The terminal is all that the parent can hear, so say why nothing else will arrive */
+        write(STDERR_FILENO, "Could not start ", 16);
+        write(STDERR_FILENO, program, program_len);
+        write(STDERR_FILENO, "\n", 1);
+        _exit(127);
+    }
+
+    /* The child holds its end of the terminal now */
+    close(child_end);
+    expect_pty_free_strings(args);
+    expect_pty_free_strings(child_env);
+    free(dir);
+    free(program);
+
+    child->pid = pid;
+    child->fd = controller;
+    child->reaped = false;
+    child->code = 0;
+    return lean_io_result_mk_ok(lean_alloc_external(expect_pty_child_class(), child));
+}
+
+/* Whether the terminal has output to be read, waiting up to `timeout_ms` for some to arrive. */
+LEAN_EXPORT lean_obj_res expect_pty_poll(b_lean_obj_arg c, uint32_t timeout_ms,
+                                         lean_object *world) {
+    (void)world;
+    expect_pty_child *child = expect_pty_unwrap(c);
+    if (child->fd < 0) return lean_io_result_mk_ok(lean_box(0));
+    struct pollfd p;
+    p.fd = child->fd;
+    p.events = POLLIN;
+    p.revents = 0;
+    /* A negative timeout would mean "wait forever" */
+    int wait_ms = timeout_ms > (uint32_t)INT_MAX ? INT_MAX : (int)timeout_ms;
+    int ready;
+    do {
+        ready = poll(&p, 1, wait_ms);
+    } while (ready < 0 && errno == EINTR);
+    if (ready < 0) return expect_pty_errno("poll", errno);
+    return lean_io_result_mk_ok(lean_box(ready > 0 ? 1 : 0));
+}
+
+/*
+Reads up to `max` bytes. The result is empty at end of input, which a terminal reports as `EIO`
+once the child has exited.
+*/
+LEAN_EXPORT lean_obj_res expect_pty_read(b_lean_obj_arg c, uint32_t max, lean_object *world) {
+    (void)world;
+    expect_pty_child *child = expect_pty_unwrap(c);
+    if (child->fd < 0) return lean_io_result_mk_ok(lean_alloc_sarray(1, 0, 0));
+    uint8_t *buf = (uint8_t *)malloc(max == 0 ? 1 : max);
+    if (buf == NULL) return expect_pty_error("Out of memory");
+    ssize_t got;
+    do {
+        got = read(child->fd, buf, (size_t)max);
+    } while (got < 0 && errno == EINTR);
+    if (got < 0 && errno != EIO) {
+        int err = errno;
+        free(buf);
+        return expect_pty_errno("read", err);
+    }
+    size_t size = got < 0 ? 0 : (size_t)got;
+    lean_object *arr = lean_alloc_sarray(1, size, size);
+    memcpy(lean_sarray_cptr(arr), buf, size);
+    free(buf);
+    return lean_io_result_mk_ok(arr);
+}
+
+/*
+Sends `size` bytes to the terminal, taking up to `timeout_ms` altogether. The result is NULL once
+all of them have been sent, and the reason the rest were not otherwise.
+
+A terminal accepts only as much as its input buffer holds, and it stays full while the program has
+yet to read, so the terminal is written to without blocking and waited for in between.
+*/
+static lean_obj_res expect_pty_send(expect_pty_child *child, const uint8_t *data, size_t size,
+                                    uint32_t timeout_ms) {
+    int flags = fcntl(child->fd, F_GETFL, 0);
+    if (flags < 0) return expect_pty_errno("fcntl", errno);
+    if (fcntl(child->fd, F_SETFL, flags | O_NONBLOCK) < 0) return expect_pty_errno("fcntl", errno);
+    struct timespec started;
+    clock_gettime(CLOCK_MONOTONIC, &started);
+    lean_obj_res result = NULL;
+    size_t written = 0;
+    while (written < size) {
+        struct timespec now;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        long waited = (now.tv_sec - started.tv_sec) * 1000 +
+                      (now.tv_nsec - started.tv_nsec) / 1000000;
+        long left = (long)timeout_ms - waited;
+        if (left <= 0) {
+            result = expect_pty_error("Timed out sending to the program");
+            break;
+        }
+        struct pollfd p;
+        p.fd = child->fd;
+        p.events = POLLOUT;
+        p.revents = 0;
+        int ready;
+        do {
+            ready = poll(&p, 1, left > (long)INT_MAX ? INT_MAX : (int)left);
+        } while (ready < 0 && errno == EINTR);
+        if (ready < 0) {
+            result = expect_pty_errno("poll", errno);
+            break;
+        }
+        if (ready == 0) {
+            result = expect_pty_error("Timed out sending to the program");
+            break;
+        }
+        ssize_t n = write(child->fd, data + written, size - written);
+        if (n < 0) {
+            if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) continue;
+            result = expect_pty_errno("write", errno);
+            break;
+        }
+        written += (size_t)n;
+    }
+    /* The other calls read the terminal as a blocking one */
+    fcntl(child->fd, F_SETFL, flags);
+    return result;
+}
+
+/* Sends `bytes` to the terminal, taking up to `timeout_ms` altogether. */
+LEAN_EXPORT lean_obj_res expect_pty_write(b_lean_obj_arg c, b_lean_obj_arg bytes,
+                                          uint32_t timeout_ms, lean_object *world) {
+    (void)world;
+    expect_pty_child *child = expect_pty_unwrap(c);
+    if (child->fd < 0) return expect_pty_error("The terminal has been released");
+    lean_obj_res failed = expect_pty_send(child, lean_sarray_cptr((lean_object *)bytes),
+                                          lean_sarray_size((lean_object *)bytes), timeout_ms);
+    return failed == NULL ? lean_io_result_mk_ok(lean_box(0)) : failed;
+}
+
+/*
+Sends the character that ends the program's input, taking up to `timeout_ms`.
+
+Echo is off for the length of the write, so that the transcript holds what the program wrote and
+what was typed for it to read. A terminal that echoes this character writes it in a form of its own
+choosing, and one platform's form is another's silence.
+*/
+LEAN_EXPORT lean_obj_res expect_pty_write_eof(b_lean_obj_arg c, uint32_t timeout_ms,
+                                              lean_object *world) {
+    (void)world;
+    expect_pty_child *child = expect_pty_unwrap(c);
+    if (child->fd < 0) return expect_pty_error("The terminal has been released");
+
+    struct termios settings;
+    struct termios quiet;
+    bool quieted = false;
+    if (tcgetattr(child->fd, &settings) == 0) {
+        quiet = settings;
+        quiet.c_lflag &= ~(tcflag_t)ECHO;
+        quieted = tcsetattr(child->fd, TCSANOW, &quiet) == 0;
+    }
+
+    const uint8_t eot = 0x04;
+    lean_obj_res failed = expect_pty_send(child, &eot, 1, timeout_ms);
+
+    if (quieted) tcsetattr(child->fd, TCSANOW, &settings);
+    return failed == NULL ? lean_io_result_mk_ok(lean_box(0)) : failed;
+}
+
+/*
+Waits up to `timeout_ms` for the child to terminate, giving its exit code, or `none` if it is
+still running. A child killed by a signal reports 128 plus the signal number, as a shell does.
+*/
+LEAN_EXPORT lean_obj_res expect_pty_wait(b_lean_obj_arg c, uint32_t timeout_ms,
+                                         lean_object *world) {
+    (void)world;
+    expect_pty_child *child = expect_pty_unwrap(c);
+    /* A signal cuts a sleep short, so the time that has passed is read from the clock. */
+    struct timespec started;
+    clock_gettime(CLOCK_MONOTONIC, &started);
+    while (true) {
+        if (child->reaped) {
+            lean_object *some = lean_alloc_ctor(1, 1, 0);
+            lean_ctor_set(some, 0, lean_box_uint32(child->code));
+            return lean_io_result_mk_ok(some);
+        }
+        int status = 0;
+        pid_t done = waitpid(child->pid, &status, WNOHANG);
+        if (done < 0) {
+            if (errno == EINTR) continue;
+            return expect_pty_errno("waitpid", errno);
+        }
+        if (done > 0) {
+            child->reaped = true;
+            if (WIFEXITED(status)) child->code = (uint32_t)WEXITSTATUS(status);
+            else if (WIFSIGNALED(status)) child->code = 128 + (uint32_t)WTERMSIG(status);
+            continue;
+        }
+        struct timespec now;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        long waited = (now.tv_sec - started.tv_sec) * 1000 +
+                      (now.tv_nsec - started.tv_nsec) / 1000000;
+        if (waited >= (long)timeout_ms) return lean_io_result_mk_ok(lean_box(0));
+        struct timespec pause;
+        pause.tv_sec = 0;
+        pause.tv_nsec = 2000000;
+        nanosleep(&pause, NULL);
+    }
+}
+
+LEAN_EXPORT lean_obj_res expect_pty_kill(b_lean_obj_arg c, lean_object *world) {
+    (void)world;
+    expect_pty_child *child = expect_pty_unwrap(c);
+    if (!child->reaped) {
+        kill(child->pid, SIGKILL);
+        expect_pty_reap(child);
+    }
+    return lean_io_result_mk_ok(lean_box(0));
+}
+
+LEAN_EXPORT lean_obj_res expect_pty_close(b_lean_obj_arg c, lean_object *world) {
+    (void)world;
+    expect_pty_child *child = expect_pty_unwrap(c);
+    if (child->fd >= 0) {
+        close(child->fd);
+        child->fd = -1;
+    }
+    return lean_io_result_mk_ok(lean_box(0));
+}

--- a/book/lakefile.lean
+++ b/book/lakefile.lean
@@ -71,6 +71,19 @@ target buildExamples (pkg) : Unit := do
 target syncBuildExamples : Unit := do
   .pure <$> (← buildExamples.fetch).await
 
+target pty.o pkg : System.FilePath := do
+  let src ← inputTextFile <| pkg.dir / "expect" / "native" / "pty.c"
+  let oFile := pkg.buildDir / "native" / "pty.o"
+  -- The Lean toolchain is part of the trace, because the object is compiled against its headers
+  buildO oFile src #["-I", (← getLeanIncludeDir).toString] #["-fPIC"] "cc" getLeanTrace
+
+lean_lib Expect where
+  srcDir := "expect"
+  precompileModules := true
+  -- The terminal code is part of the library, so that a change to it reaches everything that
+  -- elaborates against the library
+  moreLinkObjs := #[pty.o]
+
 lean_lib FPLean where
   needs := #[syncBuildExamples]
 

--- a/examples/early-return/expected
+++ b/examples/early-return/expected
@@ -1,3 +1,0 @@
-How would you like to be addressed?
-David
-Hello, David!

--- a/examples/early-return/no-name
+++ b/examples/early-return/no-name
@@ -1,9 +1,0 @@
-#!/usr/bin/expect -f
-log_user 0
-spawn lean --run EarlyReturn.lean
-log_user 1
-
-expect "?"
-send "\n"
-expect "Hello, David!"
-

--- a/examples/early-return/run
+++ b/examples/early-return/run
@@ -1,9 +1,0 @@
-#!/usr/bin/expect -f
-log_user 0
-spawn lean --run EarlyReturn.lean
-log_user 1
-
-expect "?"
-send "David\n"
-expect "Hello, David!"
-

--- a/examples/early-return/too-many-args
+++ b/examples/early-return/too-many-args
@@ -1,6 +1,0 @@
-#!/usr/bin/expect -f
-log_user 0
-spawn lean --run EarlyReturn.lean David
-log_user 1
-
-expect "Expected no arguments, but got 1"

--- a/examples/hello-name/run
+++ b/examples/hello-name/run
@@ -1,9 +1,0 @@
-#!/usr/bin/expect -f
-log_user 0
-spawn lean --run HelloName.lean
-log_user 1
-
-expect "?"
-send "David\n"
-expect "Hello, David!"
-

--- a/examples/sort-demo/run-usage
+++ b/examples/sort-demo/run-usage
@@ -1,6 +1,0 @@
-#!/usr/bin/expect -f
-log_user 0
-spawn sort
-log_user 1
-
-expect "Expected single argument"


### PR DESCRIPTION
This PR removes the need to have `expect` installed, making it easier to build the book. At the same time, the setup was greatly simplified and more moved into Verso proper.