### PR TITLE
fix doug version with ReaderT

### DIFF
--- a/book/FPLean/MonadTransformers/ReaderIO.lean
+++ b/book/FPLean/MonadTransformers/ReaderIO.lean
@@ -395,10 +395,10 @@ Indeed, it is enough to define {anchorName showFileAndDir}`showFileName` and {an
 
 ```anchor showFileAndDir
 def showFileName (file : String) : ConfigIO Unit := do
-  IO.println s!"{(← read).currentPrefix} {file}"
+  IO.println ((← read).fileName file)
 
 def showDirName (dir : String) : ConfigIO Unit := do
-  IO.println s!"{(← read).currentPrefix} {dir}/"
+  IO.println ((← read).dirName dir)
 ```
 
 One final operation from the original {anchorName ConfigIO}`ConfigIO` remains to be translated to a use of {anchorName MyReaderT}`ReaderT`: {anchorName locally}`locally`.

--- a/examples/douglib/DirTree.lean
+++ b/examples/douglib/DirTree.lean
@@ -258,10 +258,10 @@ instance : MonadLift m (ReaderT ρ m) where
 
 -- ANCHOR: showFileAndDir
 def showFileName (file : String) : ConfigIO Unit := do
-  IO.println s!"{(← read).currentPrefix} {file}"
+  IO.println ((← read).fileName file)
 
 def showDirName (dir : String) : ConfigIO Unit := do
-  IO.println s!"{(← read).currentPrefix} {dir}/"
+  IO.println ((← read).dirName dir)
 -- ANCHOR_END: showFileAndDir
 
 


### PR DESCRIPTION
The showFileName and showDirName functions were not using the helpers Config.fileName and Config.dirName, thus producing incorrect output.