### PR TITLE
chore: update plausible.io snippet to newest version

### DIFF
--- a/book/.verso/verso-xref-manifest.json
+++ b/book/.verso/verso-xref-manifest.json
@@ -1,7 +1,8 @@
 {"version": 0,
  "sources":
  {"manual":
-  {"updateFrequency": "manual",
+  {"updated": "2026-09-02:08:02:39.686733000",
+   "updateFrequency": "manual",
    "shortName": "ref",
    "root": "https://lean-lang.org/doc/reference/4.26.0/",
    "longName": "Lean Language Reference"}},

--- a/book/Main.lean
+++ b/book/Main.lean
@@ -6,7 +6,11 @@ open Verso Code External
 
 open Verso.Output.Html in
 def plausible := {{
-    <script defer="defer" data-domain="lean-lang.org" src="https://plausible.io/js/script.outbound-links.js"></script>
+    <script async src="https://plausible.io/js/pa-RTua_4FfKHhfAvAc3liZd.js"></script>
+    <script>{{Verso.Output.Html.text false r#"
+      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+      plausible.init()
+    "#}}</script>
   }}
 
 


### PR DESCRIPTION
This PR update the Plausible.io snippet used for web analytics on lean-lang.org. Plausible does not store persistent or identifying data. See their [privacy statement](https://plausible.io/privacy-focused-web-analytics) for more info.